### PR TITLE
#### SSG-002: Build Site Configuration Form

### DIFF
--- a/nbhd/src/__tests__/components/SiteConfigForm.test.jsx
+++ b/nbhd/src/__tests__/components/SiteConfigForm.test.jsx
@@ -1,0 +1,274 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { SiteConfigForm } from '../../components/SiteBuilder/SiteConfigForm';
+
+// Mock template data with schema
+const mockTemplate = {
+  id: 'blog',
+  name: 'Blog',
+  schema: {
+    type: 'object',
+    properties: {
+      title: {
+        type: 'string',
+        label: 'Site Title',
+        required: true,
+        maxLength: 100
+      },
+      author: {
+        type: 'string',
+        label: 'Author Name',
+        required: true
+      },
+      description: {
+        type: 'string',
+        label: 'Site Description',
+        widget: 'textarea',
+        maxLength: 500
+      },
+      accentColor: {
+        type: 'string',
+        label: 'Accent Color',
+        widget: 'color',
+        default: '#007bff'
+      }
+    }
+  }
+};
+
+describe('SiteConfigForm', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  // [x] Read `config.schema.json` from selected template
+  it('renders form with template schema', () => {
+    render(
+      <BrowserRouter>
+        <SiteConfigForm template={mockTemplate} />
+      </BrowserRouter>
+    );
+
+    expect(screen.getByTestId('config-form')).toBeInTheDocument();
+  });
+
+  // [x] Form renders all schema fields correctly
+  it('renders all form fields from schema', () => {
+    render(
+      <BrowserRouter>
+        <SiteConfigForm template={mockTemplate} />
+      </BrowserRouter>
+    );
+
+    // Check for all fields
+    expect(screen.getByLabelText(/Site Title/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Author Name/)).toBeInTheDocument();
+    expect(screen.getByLabelText('Site Description')).toBeInTheDocument();
+    expect(screen.getByLabelText('Accent Color')).toBeInTheDocument();
+  });
+
+  // [x] Generate form inputs based on schema (text, textarea, color picker, etc)
+  it('generates correct input types based on schema widget', () => {
+    render(
+      <BrowserRouter>
+        <SiteConfigForm template={mockTemplate} />
+      </BrowserRouter>
+    );
+
+    const textarea = screen.getByLabelText('Site Description');
+    expect(textarea.tagName).toBe('TEXTAREA');
+
+    const colorInput = screen.getByLabelText('Accent Color');
+    expect(colorInput.type).toBe('color');
+
+    const titleInput = screen.getByLabelText(/Site Title/);
+    expect(titleInput.type).toBe('text');
+  });
+
+  // [x] Real-time preview updates as user types
+  it('triggers preview updates when user types', () => {
+    const mockOnPreviewUpdate = vi.fn();
+    render(
+      <BrowserRouter>
+        <SiteConfigForm template={mockTemplate} onPreviewUpdate={mockOnPreviewUpdate} />
+      </BrowserRouter>
+    );
+
+    const titleInput = screen.getByLabelText(/Site Title/);
+    fireEvent.change(titleInput, { target: { value: 'My Blog' } });
+
+    expect(mockOnPreviewUpdate).toHaveBeenCalled();
+  });
+
+  // [x] "Preview" and "Deploy" buttons
+  it('renders Preview and Deploy buttons', () => {
+    render(
+      <BrowserRouter>
+        <SiteConfigForm template={mockTemplate} />
+      </BrowserRouter>
+    );
+
+    expect(screen.getByRole('button', { name: /preview/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /deploy/i })).toBeInTheDocument();
+  });
+
+  // [x] Save draft configurations locally (localStorage)
+  it('saves draft configuration to localStorage after delay', () => {
+    vi.useFakeTimers();
+    const siteId = 'site-001';
+
+    render(
+      <BrowserRouter>
+        <SiteConfigForm template={mockTemplate} siteId={siteId} />
+      </BrowserRouter>
+    );
+
+    const titleInput = screen.getByLabelText(/Site Title/);
+    fireEvent.change(titleInput, { target: { value: 'My Blog' } });
+
+    // Advance timers 30 seconds
+    vi.advanceTimersByTime(30000);
+
+    const saved = localStorage.getItem(`site-draft-${siteId}`);
+    expect(saved).toBeTruthy();
+    const config = JSON.parse(saved);
+    expect(config.title).toBe('My Blog');
+
+    vi.useRealTimers();
+  });
+
+  // [x] Draft auto-saves every 30 seconds
+  it('auto-saves draft every 30 seconds', () => {
+    vi.useFakeTimers();
+    const siteId = 'site-002';
+    const mockOnSave = vi.fn();
+
+    render(
+      <BrowserRouter>
+        <SiteConfigForm template={mockTemplate} siteId={siteId} onSave={mockOnSave} />
+      </BrowserRouter>
+    );
+
+    const titleInput = screen.getByLabelText(/Site Title/);
+    fireEvent.change(titleInput, { target: { value: 'New Blog' } });
+
+    // Auto-save happens after 30 seconds
+    vi.advanceTimersByTime(30000);
+
+    expect(mockOnSave).toHaveBeenCalledWith(expect.objectContaining({
+      title: 'New Blog'
+    }));
+
+    vi.useRealTimers();
+  });
+
+  // [x] Validation matches schema constraints
+  it('validates form inputs against schema constraints (maxLength)', () => {
+    render(
+      <BrowserRouter>
+        <SiteConfigForm template={mockTemplate} />
+      </BrowserRouter>
+    );
+
+    const titleInput = screen.getByLabelText(/Site Title/);
+
+    // Try to exceed maxLength
+    fireEvent.change(titleInput, {
+      target: { value: 'A'.repeat(101) }
+    });
+
+    // Component should prevent exceeding maxLength
+    expect(titleInput.value.length).toBeLessThanOrEqual(100);
+  });
+
+  // [x] Form persists across page refreshes
+  it('persists form data across page refreshes from localStorage', () => {
+    const siteId = 'site-003';
+    const initialConfig = {
+      title: 'My Blog',
+      author: 'John Doe',
+      description: 'A blog about life',
+      accentColor: '#ff0000'
+    };
+
+    // Pre-populate localStorage
+    localStorage.setItem(`site-draft-${siteId}`, JSON.stringify(initialConfig));
+
+    render(
+      <BrowserRouter>
+        <SiteConfigForm template={mockTemplate} siteId={siteId} />
+      </BrowserRouter>
+    );
+
+    // Component should load from localStorage
+    expect(screen.getByLabelText(/Site Title/)).toHaveValue('My Blog');
+    expect(screen.getByLabelText(/Author Name/)).toHaveValue('John Doe');
+    expect(screen.getByLabelText('Site Description')).toHaveValue('A blog about life');
+  });
+
+  // Test required field validation
+  it('prevents deploy if required fields are missing', () => {
+    const mockOnDeploy = vi.fn();
+    render(
+      <BrowserRouter>
+        <SiteConfigForm template={mockTemplate} onDeploy={mockOnDeploy} />
+      </BrowserRouter>
+    );
+
+    const deployButton = screen.getByRole('button', { name: /deploy/i });
+    fireEvent.click(deployButton);
+
+    // Should not call deploy when validation fails
+    expect(mockOnDeploy).not.toHaveBeenCalled();
+  });
+
+  // Test Preview button functionality
+  it('calls preview handler when Preview button is clicked with valid data', () => {
+    const mockOnPreview = vi.fn();
+    render(
+      <BrowserRouter>
+        <SiteConfigForm template={mockTemplate} onPreview={mockOnPreview} />
+      </BrowserRouter>
+    );
+
+    const titleInput = screen.getByLabelText(/Site Title/);
+    const authorInput = screen.getByLabelText(/Author Name/);
+
+    fireEvent.change(titleInput, { target: { value: 'My Blog' } });
+    fireEvent.change(authorInput, { target: { value: 'John Doe' } });
+
+    const previewButton = screen.getByRole('button', { name: /preview/i });
+    fireEvent.click(previewButton);
+
+    expect(mockOnPreview).toHaveBeenCalledWith(expect.objectContaining({
+      title: 'My Blog',
+      author: 'John Doe'
+    }));
+  });
+
+  // Test Deploy button functionality
+  it('calls deploy handler when Deploy button is clicked with valid data', () => {
+    const mockOnDeploy = vi.fn().mockResolvedValue({});
+    render(
+      <BrowserRouter>
+        <SiteConfigForm template={mockTemplate} onDeploy={mockOnDeploy} />
+      </BrowserRouter>
+    );
+
+    const titleInput = screen.getByLabelText(/Site Title/);
+    const authorInput = screen.getByLabelText(/Author Name/);
+
+    fireEvent.change(titleInput, { target: { value: 'My Blog' } });
+    fireEvent.change(authorInput, { target: { value: 'John Doe' } });
+
+    const deployButton = screen.getByRole('button', { name: /deploy/i });
+    fireEvent.click(deployButton);
+
+    expect(mockOnDeploy).toHaveBeenCalledWith(expect.objectContaining({
+      title: 'My Blog',
+      author: 'John Doe'
+    }));
+  });
+});

--- a/nbhd/src/components/SiteBuilder/SiteConfigForm.jsx
+++ b/nbhd/src/components/SiteBuilder/SiteConfigForm.jsx
@@ -1,0 +1,292 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import styles from './SiteConfigForm.module.css';
+
+/**
+ * Renders a form field based on schema widget type
+ */
+function FormField({ schema, name, value, onChange, error }) {
+  const fieldSchema = schema.properties[name];
+  const widget = fieldSchema.widget || 'text';
+  const label = fieldSchema.label || name;
+  const required = fieldSchema.required ? '*' : '';
+  const labelText = required ? `${label} ${required}` : label;
+
+  const handleChange = (e) => {
+    let newValue = e.target.value;
+
+    // Apply maxLength constraint
+    if (fieldSchema.maxLength && newValue.length > fieldSchema.maxLength) {
+      newValue = newValue.slice(0, fieldSchema.maxLength);
+    }
+
+    onChange(name, newValue);
+  };
+
+  switch (widget) {
+    case 'textarea':
+      return (
+        <div className={styles.formGroup}>
+          <label htmlFor={name} className={styles.label}>
+            {labelText}
+          </label>
+          <textarea
+            id={name}
+            name={name}
+            value={value || ''}
+            onChange={handleChange}
+            className={styles.textarea}
+            maxLength={fieldSchema.maxLength}
+          />
+          {fieldSchema.maxLength && (
+            <small className={styles.hint}>
+              {(value || '').length} / {fieldSchema.maxLength}
+            </small>
+          )}
+          {error && <span className={styles.error}>{error}</span>}
+        </div>
+      );
+
+    case 'color':
+      return (
+        <div className={styles.formGroup}>
+          <label htmlFor={name} className={styles.label}>
+            {labelText}
+          </label>
+          <input
+            id={name}
+            type="color"
+            name={name}
+            value={value || fieldSchema.default || '#000000'}
+            onChange={handleChange}
+            className={styles.colorInput}
+          />
+          {error && <span className={styles.error}>{error}</span>}
+        </div>
+      );
+
+    case 'text':
+    default:
+      return (
+        <div className={styles.formGroup}>
+          <label htmlFor={name} className={styles.label}>
+            {labelText}
+          </label>
+          <input
+            id={name}
+            type="text"
+            name={name}
+            value={value || ''}
+            onChange={handleChange}
+            className={styles.input}
+            maxLength={fieldSchema.maxLength}
+          />
+          {fieldSchema.maxLength && (
+            <small className={styles.hint}>
+              {(value || '').length} / {fieldSchema.maxLength}
+            </small>
+          )}
+          {error && <span className={styles.error}>{error}</span>}
+        </div>
+      );
+  }
+}
+
+/**
+ * Validates form config against schema
+ */
+function validateConfig(schema, config) {
+  const errors = {};
+
+  Object.entries(schema.properties).forEach(([key, fieldSchema]) => {
+    const value = config[key];
+
+    // Check required
+    if (fieldSchema.required && (!value || value.trim() === '')) {
+      errors[key] = `${fieldSchema.label || key} is required`;
+    }
+
+    // Check maxLength
+    if (value && fieldSchema.maxLength && value.length > fieldSchema.maxLength) {
+      errors[key] = `${fieldSchema.label || key} cannot exceed ${fieldSchema.maxLength} characters`;
+    }
+  });
+
+  return errors;
+}
+
+/**
+ * SiteConfigForm - Dynamic form generator based on template schema
+ */
+export function SiteConfigForm({
+  template,
+  siteId = 'new-site',
+  onPreviewUpdate,
+  onPreview,
+  onDeploy,
+  onSave
+}) {
+  const [config, setConfig] = useState({});
+  const [errors, setErrors] = useState({});
+  const [isDirty, setIsDirty] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const autoSaveTimeoutRef = useRef(null);
+
+  // Initialize from localStorage
+  useEffect(() => {
+    const storageKey = `site-draft-${siteId}`;
+    const saved = localStorage.getItem(storageKey);
+
+    if (saved) {
+      try {
+        setConfig(JSON.parse(saved));
+      } catch (err) {
+        console.error('Failed to parse saved config:', err);
+      }
+    }
+  }, [siteId]);
+
+  // Auto-save every 30 seconds
+  useEffect(() => {
+    if (!isDirty) return;
+
+    // Clear existing timeout
+    if (autoSaveTimeoutRef.current) {
+      clearTimeout(autoSaveTimeoutRef.current);
+    }
+
+    autoSaveTimeoutRef.current = setTimeout(() => {
+      const storageKey = `site-draft-${siteId}`;
+      localStorage.setItem(storageKey, JSON.stringify(config));
+      setIsDirty(false);
+
+      if (onSave) {
+        onSave(config);
+      }
+    }, 30000);
+
+    // Cleanup
+    return () => {
+      if (autoSaveTimeoutRef.current) {
+        clearTimeout(autoSaveTimeoutRef.current);
+      }
+    };
+  }, [config, isDirty, siteId, onSave]);
+
+  const handleFieldChange = useCallback((name, value) => {
+    setConfig((prev) => ({
+      ...prev,
+      [name]: value
+    }));
+    setIsDirty(true);
+
+    // Clear error for this field
+    if (errors[name]) {
+      setErrors((prev) => {
+        const newErrors = { ...prev };
+        delete newErrors[name];
+        return newErrors;
+      });
+    }
+
+    // Trigger real-time preview
+    if (onPreviewUpdate) {
+      onPreviewUpdate({
+        ...config,
+        [name]: value
+      });
+    }
+  }, [config, errors, onPreviewUpdate]);
+
+  const handlePreview = useCallback(() => {
+    const newErrors = validateConfig(template.schema, config);
+
+    if (Object.keys(newErrors).length > 0) {
+      setErrors(newErrors);
+      return;
+    }
+
+    if (onPreview) {
+      onPreview(config);
+    }
+  }, [config, template.schema, onPreview]);
+
+  const handleDeploy = useCallback(() => {
+    const newErrors = validateConfig(template.schema, config);
+
+    if (Object.keys(newErrors).length > 0) {
+      setErrors(newErrors);
+      return;
+    }
+
+    if (onDeploy) {
+      setIsSubmitting(true);
+      onDeploy(config).finally(() => {
+        setIsSubmitting(false);
+      });
+    }
+  }, [config, template.schema, onDeploy]);
+
+  if (!template || !template.schema) {
+    return <div className={styles.container}>No template schema available</div>;
+  }
+
+  return (
+    <div className={styles.container}>
+      <form className={styles.form} data-testid="config-form" onSubmit={(e) => e.preventDefault()}>
+        <h1 className={styles.title}>Configure {template.name}</h1>
+        <p className={styles.description}>
+          Customize your site by filling in the fields below
+        </p>
+
+        <div className={styles.fields}>
+          {Object.keys(template.schema.properties).map((fieldName) => (
+            <FormField
+              key={fieldName}
+              schema={template.schema}
+              name={fieldName}
+              value={config[fieldName]}
+              onChange={handleFieldChange}
+              error={errors[fieldName]}
+            />
+          ))}
+        </div>
+
+        {Object.keys(errors).length > 0 && (
+          <div className={styles.errorSummary}>
+            <p>Please correct the following errors:</p>
+            <ul>
+              {Object.values(errors).map((error, idx) => (
+                <li key={idx}>{error}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <div className={styles.actions}>
+          <button
+            type="button"
+            className={styles.previewButton}
+            onClick={handlePreview}
+            disabled={isSubmitting}
+          >
+            Preview
+          </button>
+          <button
+            type="button"
+            className={styles.deployButton}
+            onClick={handleDeploy}
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? 'Deploying...' : 'Deploy'}
+          </button>
+        </div>
+
+        {isDirty && (
+          <div className={styles.draftIndicator}>
+            💾 Draft (auto-saving...)
+          </div>
+        )}
+      </form>
+    </div>
+  );
+}

--- a/nbhd/src/components/SiteBuilder/SiteConfigForm.module.css
+++ b/nbhd/src/components/SiteBuilder/SiteConfigForm.module.css
@@ -1,0 +1,198 @@
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.form {
+  background: white;
+  border: 1px solid #dee2e6;
+  border-radius: 8px;
+  padding: 2rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.title {
+  font-size: 1.75rem;
+  margin: 0 0 0.5rem 0;
+  color: #333;
+}
+
+.description {
+  color: #666;
+  margin: 0 0 2rem 0;
+  font-size: 1rem;
+}
+
+.fields {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.formGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.label {
+  font-weight: 500;
+  color: #333;
+  font-size: 0.95rem;
+}
+
+.input,
+.textarea,
+.colorInput {
+  padding: 0.75rem;
+  border: 1px solid #dee2e6;
+  border-radius: 6px;
+  font-size: 1rem;
+  font-family: inherit;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.input:focus,
+.textarea:focus,
+.colorInput:focus {
+  outline: none;
+  border-color: #007bff;
+  box-shadow: 0 0 0 3px rgba(0, 123, 255, 0.15);
+}
+
+.textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.colorInput {
+  max-width: 80px;
+  height: 50px;
+  cursor: pointer;
+  padding: 0.25rem;
+}
+
+.hint {
+  color: #999;
+  font-size: 0.85rem;
+  margin-top: 0.25rem;
+}
+
+.error {
+  color: #dc3545;
+  font-size: 0.85rem;
+  margin-top: 0.25rem;
+}
+
+.errorSummary {
+  background: #f8d7da;
+  border: 1px solid #f5c6cb;
+  border-radius: 6px;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+  color: #721c24;
+}
+
+.errorSummary p {
+  margin: 0 0 0.5rem 0;
+  font-weight: 500;
+}
+
+.errorSummary ul {
+  margin: 0;
+  padding-left: 1.5rem;
+}
+
+.errorSummary li {
+  margin: 0.25rem 0;
+}
+
+.actions {
+  display: flex;
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.previewButton,
+.deployButton {
+  flex: 1;
+  padding: 0.875rem 1.5rem;
+  border: none;
+  border-radius: 6px;
+  font-size: 1rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.previewButton {
+  background: #6c757d;
+  color: white;
+}
+
+.previewButton:hover:not(:disabled) {
+  background: #5a6268;
+}
+
+.previewButton:active:not(:disabled) {
+  background: #4e555b;
+}
+
+.previewButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.deployButton {
+  background: #28a745;
+  color: white;
+}
+
+.deployButton:hover:not(:disabled) {
+  background: #218838;
+}
+
+.deployButton:active:not(:disabled) {
+  background: #1e7e34;
+}
+
+.deployButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.draftIndicator {
+  margin-top: 1rem;
+  padding: 0.75rem 1rem;
+  background: #e7f3ff;
+  border-left: 4px solid #007bff;
+  color: #004085;
+  font-size: 0.9rem;
+  border-radius: 4px;
+}
+
+/* Mobile responsive */
+@media (max-width: 768px) {
+  .container {
+    padding: 1rem;
+  }
+
+  .form {
+    padding: 1.5rem;
+  }
+
+  .title {
+    font-size: 1.5rem;
+  }
+
+  .actions {
+    flex-direction: column;
+  }
+
+  .previewButton,
+  .deployButton {
+    flex: auto;
+  }
+}

--- a/nbhd/vitest.config.js
+++ b/nbhd/vitest.config.js
@@ -7,5 +7,6 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./src/__tests__/setup.js'],
+    testTimeout: 10000,
   },
 });


### PR DESCRIPTION
#### SSG-002: Build Site Configuration Form
- **Description:** Create dynamic form generator for template-specific config fields
- **Requirements:**
  - [x] Read `config.schema.json` from selected template
  - [x] Generate form inputs based on schema (text, textarea, color picker, etc)
  - [x] Real-time preview updates as user types
  - [x] Save draft configurations locally (localStorage)
  - [x] "Preview" and "Deploy" buttons
- **Acceptance Criteria:**
  - [x] Form renders all schema fields correctly
  - [x] Draft auto-saves every 30 seconds
  - [x] Validation matches schema constraints
  - [x] Form persists across page refreshes
- **Type:** Feature
- **Estimate:** M