### PR TITLE
feat(FL-9.1): Implement context-aware home page

### DIFF
--- a/app/UI/src/App.jsx
+++ b/app/UI/src/App.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { HashRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import { AuthProvider } from './contexts/AuthContext';
+import HomePage from './pages/HomePage';
 import Login from './pages/Login';
 import AuthSuccess from './pages/AuthSuccess';
 import Dashboard from './pages/Dashboard';
@@ -32,7 +33,7 @@ function App() {
           <Route path="/my-nbhds" element={<MyNbhds />} />
           <Route path="/personal-sites" element={<PersonalSites />} />
           <Route path="/project-sites" element={<ProjectSites />} />
-          <Route path="/" element={<Navigate to="/dashboard" replace />} />
+          <Route path="/" element={<HomePage />} />
         </Routes>
       </AuthProvider>
     </Router>

--- a/app/UI/src/components/WelcomePageContent.jsx
+++ b/app/UI/src/components/WelcomePageContent.jsx
@@ -1,0 +1,106 @@
+import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { nbhdContentService } from '../services/nbhdContentService';
+import MarkdownRenderer from './MarkdownRenderer';
+import DefaultWelcomeInstructions from './DefaultWelcomeInstructions';
+import styles from '../styles/WelcomePage.module.css';
+
+/**
+ * WelcomePageContent - Reusable component for displaying neighborhood welcome content
+ * Can be used by both the standalone WelcomePage and the HomePage
+ *
+ * Props:
+ * - nbhd: Neighborhood object with id and name
+ * - showBackLink: (optional) Show back link to neighborhood detail page (default: true)
+ */
+export default function WelcomePageContent({ nbhd, showBackLink = true }) {
+  const [welcomeContent, setWelcomeContent] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (nbhd && nbhd.id) {
+      fetchWelcomeContent();
+    }
+  }, [nbhd]);
+
+  const fetchWelcomeContent = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      // Fetch welcome content
+      const content = await nbhdContentService.getWelcomeContent(nbhd.id);
+      setWelcomeContent(content.data);
+    } catch (contentErr) {
+      // Welcome content doesn't exist - that's okay
+      if (contentErr.response?.status === 404 || contentErr.response?.data?.data === null) {
+        setWelcomeContent(null);
+      } else {
+        setError(contentErr.response?.data?.detail || contentErr.message || 'Failed to load welcome content');
+        console.error('Error fetching welcome content:', contentErr);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className={styles.container}>
+        <div className={styles.loading}>Loading...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className={styles.container}>
+        <div className={styles.error}>
+          <h2>Error</h2>
+          <p>{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.container}>
+      <header className={styles.header}>
+        {showBackLink && (
+          <Link to={`/nbhds/${nbhd.id}`} className={styles.backLink}>
+            ← Back to {nbhd.name}
+          </Link>
+        )}
+        <h1>{nbhd.name}</h1>
+      </header>
+
+      <div className={styles.content}>
+        {welcomeContent ? (
+          <div className={styles.welcomeContent}>
+            <h2>{welcomeContent.value?.title || 'Welcome'}</h2>
+            <MarkdownRenderer markdown={welcomeContent.value?.content || ''} />
+            <div className={styles.meta}>
+              Last updated:{' '}
+              {new Date(welcomeContent.value?.updated_at).toLocaleDateString()}
+            </div>
+          </div>
+        ) : (
+          <DefaultWelcomeInstructions />
+        )}
+      </div>
+
+      <footer className={styles.footer}>
+        {showBackLink ? (
+          <Link to={`/nbhds/${nbhd.id}`} className={styles.button}>
+            View Neighborhood Details
+          </Link>
+        ) : (
+          <Link to="/login" className={styles.button}>
+            Sign In
+          </Link>
+        )}
+      </footer>
+    </div>
+  );
+}

--- a/app/UI/src/pages/HomePage.jsx
+++ b/app/UI/src/pages/HomePage.jsx
@@ -1,0 +1,76 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+import { nbhdService } from '../services/neighborhoodService';
+import WelcomePageContent from '../components/WelcomePageContent';
+import Login from './Login';
+import styles from '../styles/HomePage.module.css';
+
+/**
+ * HomePage - Smart home page router
+ *
+ * Routing Logic:
+ * 1. If user is authenticated → redirect to /dashboard
+ * 2. If home neighborhood exists → show welcome page
+ * 3. Otherwise → show login page
+ *
+ * Acceptance Criteria:
+ * - [x] Unauthenticated users see home page (nbhd welcome or login)
+ * - [x] Authenticated users redirected to dashboard
+ * - [x] No error if no nbhd designated as home page
+ * - [x] Loading state displays while checking
+ * - [x] Navigation handles both logged-in and logged-out states
+ * - [x] Home page context switches work without full reload
+ */
+export default function HomePage() {
+  const { isAuthenticated, isLoading: authLoading } = useAuth();
+  const navigate = useNavigate();
+  const [homeNbhd, setHomeNbhd] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  // Effect 1: Fetch home neighborhood on mount
+  useEffect(() => {
+    checkHomePage();
+  }, []);
+
+  // Effect 2: Redirect authenticated users to dashboard
+  useEffect(() => {
+    if (!authLoading && isAuthenticated) {
+      navigate('/dashboard', { replace: true });
+    }
+  }, [isAuthenticated, authLoading, navigate]);
+
+  const checkHomePage = async () => {
+    try {
+      setLoading(true);
+      const nbhd = await nbhdService.getHomeNbhd();
+      setHomeNbhd(nbhd);
+    } catch (err) {
+      console.error('Error fetching home page neighborhood:', err);
+      // If error fetching home page, just continue to show login
+      setHomeNbhd(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Show loading state while checking auth and home page
+  if (authLoading || loading) {
+    return (
+      <div className={styles.container}>
+        <div className={styles.loading}>Loading...</div>
+      </div>
+    );
+  }
+
+  // If authenticated, they will be redirected by the useEffect
+  // This component only renders for unauthenticated users
+
+  // Show welcome page if home neighborhood is configured
+  if (homeNbhd) {
+    return <WelcomePageContent nbhd={homeNbhd} showBackLink={false} />;
+  }
+
+  // Fall back to login page if no home neighborhood
+  return <Login />;
+}

--- a/app/UI/src/pages/WelcomePage.jsx
+++ b/app/UI/src/pages/WelcomePage.jsx
@@ -1,9 +1,7 @@
 import React, { useState, useEffect } from 'react';
-import { useParams, useNavigate, Link } from 'react-router-dom';
-import { nbhdContentService } from '../services/nbhdContentService';
+import { useParams, useNavigate } from 'react-router-dom';
 import { nbhdService } from '../services/neighborhoodService';
-import MarkdownRenderer from '../components/MarkdownRenderer';
-import DefaultWelcomeInstructions from '../components/DefaultWelcomeInstructions';
+import WelcomePageContent from '../components/WelcomePageContent';
 import styles from '../styles/WelcomePage.module.css';
 
 /**
@@ -23,15 +21,14 @@ export default function WelcomePage() {
   const navigate = useNavigate();
 
   const [nbhd, setNbhd] = useState(null);
-  const [welcomeContent, setWelcomeContent] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
   useEffect(() => {
-    fetchData();
+    fetchNbhd();
   }, [id]);
 
-  const fetchData = async () => {
+  const fetchNbhd = async () => {
     try {
       setLoading(true);
       setError(null);
@@ -39,22 +36,9 @@ export default function WelcomePage() {
       // Fetch neighborhood details (to verify it exists)
       const nbhdData = await nbhdService.getNbhd(id);
       setNbhd(nbhdData);
-
-      // Fetch welcome content (might not exist)
-      try {
-        const content = await nbhdContentService.getWelcomeContent(id);
-        setWelcomeContent(content.data);
-      } catch (contentErr) {
-        // Welcome content doesn't exist - that's okay
-        if (contentErr.response?.status === 404 || contentErr.response?.data?.data === null) {
-          setWelcomeContent(null);
-        } else {
-          throw contentErr;
-        }
-      }
     } catch (err) {
-      setError(err.response?.data?.detail || err.message || 'Failed to load welcome page');
-      console.error('Error fetching welcome page:', err);
+      setError(err.response?.data?.detail || err.message || 'Failed to load neighborhood');
+      console.error('Error fetching neighborhood:', err);
     } finally {
       setLoading(false);
     }
@@ -82,35 +66,5 @@ export default function WelcomePage() {
     );
   }
 
-  return (
-    <div className={styles.container}>
-      <header className={styles.header}>
-        <Link to={`/nbhds/${id}`} className={styles.backLink}>
-          ← Back to {nbhd?.name || 'Neighborhood'}
-        </Link>
-        <h1>{nbhd?.name}</h1>
-      </header>
-
-      <div className={styles.content}>
-        {welcomeContent ? (
-          <div className={styles.welcomeContent}>
-            <h2>{welcomeContent.value?.title || 'Welcome'}</h2>
-            <MarkdownRenderer markdown={welcomeContent.value?.content || ''} />
-            <div className={styles.meta}>
-              Last updated:{' '}
-              {new Date(welcomeContent.value?.updated_at).toLocaleDateString()}
-            </div>
-          </div>
-        ) : (
-          <DefaultWelcomeInstructions />
-        )}
-      </div>
-
-      <footer className={styles.footer}>
-        <Link to={`/nbhds/${id}`} className={styles.button}>
-          View Neighborhood Details
-        </Link>
-      </footer>
-    </div>
-  );
+  return nbhd ? <WelcomePageContent nbhd={nbhd} showBackLink={true} /> : null;
 }

--- a/app/UI/src/services/neighborhoodService.js
+++ b/app/UI/src/services/neighborhoodService.js
@@ -37,6 +37,23 @@ export const nbhdService = {
   },
 
   /**
+   * Get the neighborhood designated as the home page
+   * @returns {Promise<Object|null>} Home page neighborhood or null if not configured
+   */
+  async getHomeNbhd() {
+    try {
+      const response = await apiClient.get('/api/nbhds/home');
+      return response.data;
+    } catch (err) {
+      // If endpoint returns 404 or other error, return null
+      if (err.response?.status === 404 || !err.response) {
+        return null;
+      }
+      throw err;
+    }
+  },
+
+  /**
    * Join a nbhd
    * @param {number} id - Nbhd ID
    * @returns {Promise<Object>} Join response

--- a/app/UI/src/styles/HomePage.module.css
+++ b/app/UI/src/styles/HomePage.module.css
@@ -1,0 +1,14 @@
+.container {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: #f5f5f5;
+}
+
+.loading {
+  font-size: 1.2rem;
+  color: #666;
+  text-align: center;
+}

--- a/app/api/models.py
+++ b/app/api/models.py
@@ -97,6 +97,7 @@ class NbhdResponse(BaseModel):
     created_at: str  # ISO format timestamp string
     member_count: int = 0
     nbhd_did: str  # DID for AT Protocol compatibility
+    settings: Optional[Dict] = {}  # Neighborhood settings (is_home_page, etc)
 
     class Config:
         from_attributes = True

--- a/app/api/nbhd.py
+++ b/app/api/nbhd.py
@@ -38,6 +38,28 @@ async def list_nbhds(limit: int = 100, last_key: Optional[str] = None):
         return nbhds
 
 
+@router.get("/api/nbhds/home", response_model=Optional[NbhdResponse])
+async def get_home_nbhd():
+    """
+    Get the neighborhood designated as the home page.
+    Returns the first neighborhood with is_home_page=true in settings.
+    Returns null if no home page neighborhood is configured.
+    Public endpoint - no authentication required.
+    """
+    async with get_table() as table:
+        # Query all neighborhoods using existing list function
+        nbhds, _ = await list_neighborhoods(table, limit=100)
+
+        # Find neighborhood with is_home_page = true in settings
+        for nbhd in nbhds:
+            settings = nbhd.get("settings", {})
+            if settings.get("is_home_page") is True:
+                return nbhd
+
+        # No home page neighborhood configured
+        return None
+
+
 @router.get("/api/nbhds/{nbhd_id}", response_model=NbhdDetailResponse)
 async def get_nbhd_detail(nbhd_id: str):
     """
@@ -70,6 +92,8 @@ async def get_nbhd_detail(nbhd_id: str):
             created_by=nbhd["created_by"],
             created_at=nbhd["created_at"],
             member_count=nbhd.get("member_count", 0),
+            nbhd_did=nbhd.get("nbhd_did", ""),
+            settings=nbhd.get("settings", {}),
             members=member_responses,
         )
 


### PR DESCRIPTION
## Summary

Implement intelligent home page routing that displays appropriate content based on user authentication state and neighborhood configuration.

**Routing Logic:**
- Authenticated users → Redirect to `/dashboard`
- Unauthenticated users + home page neighborhood configured → Show neighborhood welcome page
- Unauthenticated users + no home page → Show login page

## Changes Made

### Backend
- ✅ New API endpoint: `GET /api/nbhds/home` - Returns the home page neighborhood or null
- ✅ Updated `NbhdResponse` model - Added optional `settings` field for `is_home_page` flag
- ✅ Updated neighborhood detail endpoint - Include `nbhd_did` and `settings` in responses

### Frontend
- ✅ New component: `HomePage.jsx` - Smart router with conditional rendering
- ✅ New component: `WelcomePageContent.jsx` - Reusable welcome content renderer
- ✅ Refactored: `WelcomePage.jsx` - Uses new WelcomePageContent component
- ✅ Updated: `neighborhoodService.js` - Added `getHomeNbhd()` method
- ✅ Updated: `App.jsx` - Route "/" to HomePage instead of Navigate

## Implementation Details

### Backend Endpoint
```python
GET /api/nbhds/home
- Returns: NbhdResponse with is_home_page=true, or null
- Public: No authentication required
- Query: Scans neighborhoods for is_home_page setting
```

### HomePage Logic
1. Check authentication state while loading home neighborhood
2. Redirect authenticated users to dashboard immediately
3. Show WelcomePageContent if home neighborhood exists
4. Fall back to Login page if no home neighborhood configured

## Testing Plan

### Manual Scenarios
1. **No home page configured** → Shows login page
2. **Home page with content** → Shows welcome page with markdown
3. **Home page without content** → Shows default instructions
4. **Authenticated user** → Redirects to dashboard
5. **Loading states** → Spinner displays during fetch

### API Verification
```bash
# Test endpoint
curl http://localhost:8000/api/nbhds/home

# Should return:
# - Neighborhood object (if is_home_page=true exists)
# - null (if no home page configured)
```

## Testing Checklist
- [ ] Setup: Set `is_home_page: true` on a test neighborhood in DynamoDB
- [ ] Setup: Create welcome content for that neighborhood
- [ ] Scenario 1: Unauth + home page = shows welcome
- [ ] Scenario 2: Unauth + no home = shows login
- [ ] Scenario 3: Auth = redirects to dashboard
- [ ] Scenario 4: Loading states visible
- [ ] Scenario 5: Missing content shows defaults
- [ ] Verify: `/nbhds/:id/welcome` still works

## Acceptance Criteria

- [x] Unauthenticated users see home page (nbhd welcome or login)
- [x] Authenticated users see personal dashboard
- [x] No error if no nbhd designated as home page
- [x] Loading state displays while checking for home page content
- [x] Navigation handles both logged-in and logged-out states correctly
- [x] Home page context switches work without full page reload
- [x] Backend endpoint returns correct neighborhood
- [x] Settings field included in neighborhood responses
- [x] Welcome content renders correctly on home page
- [x] Falls back to login page when no home page set
- [x] Handles missing welcome content gracefully

## Related Issues

- Ticket: FL-9.1 (Context-Aware Home Page)
- Phase: 9.1 (Frontend Login & Authentication)
- Depends on: Phase 1 (BlueSky OAuth), Phase 7 (Neighborhoods)

🤖 Generated with [Claude Code](https://claude.com/claude-code)