### PR TITLE
feat: SSG-034 Site Settings & Configuration

### DIFF
--- a/app/UI/src/components/CMS/SiteSettings.module.css
+++ b/app/UI/src/components/CMS/SiteSettings.module.css
@@ -1,0 +1,270 @@
+.settingsPage {
+  max-width: 700px;
+  padding: 2rem;
+}
+
+.settingsPage h2 {
+  font-size: 1.8rem;
+  margin-bottom: 1.5rem;
+  color: #333;
+}
+
+.section {
+  margin-bottom: 2.5rem;
+  padding: 1.5rem;
+  background: #f9f9f9;
+  border-radius: 8px;
+  border: 1px solid #e0e0e0;
+}
+
+.section h3 {
+  font-size: 1.1rem;
+  margin-bottom: 1rem;
+  color: #555;
+  text-transform: uppercase;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+}
+
+.formGroup {
+  margin-bottom: 1.5rem;
+}
+
+.formGroup label {
+  display: block;
+  font-weight: 500;
+  margin-bottom: 0.5rem;
+  color: #333;
+  font-size: 0.95rem;
+}
+
+.formGroup input[type="text"],
+.formGroup input[type="email"],
+.formGroup textarea {
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 0.95rem;
+  font-family: inherit;
+}
+
+.formGroup input[type="text"]:focus,
+.formGroup input[type="email"]:focus,
+.formGroup textarea:focus {
+  outline: none;
+  border-color: #4a90e2;
+  box-shadow: 0 0 0 3px rgba(74, 144, 226, 0.1);
+}
+
+.hint {
+  font-size: 0.85rem;
+  color: #999;
+  margin-top: 0.4rem;
+}
+
+.readOnly {
+  padding: 0.75rem;
+  background: #f0f0f0;
+  border: 1px solid #d0d0d0;
+  border-radius: 4px;
+  font-family: monospace;
+  color: #666;
+}
+
+.radioGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.radioGroup label {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  cursor: pointer;
+  font-weight: normal;
+  padding: 0.75rem;
+  border-radius: 4px;
+  border: 1px solid #e0e0e0;
+  margin-bottom: 0;
+}
+
+.radioGroup label:hover {
+  background: #f5f5f5;
+}
+
+.radioGroup input[type="radio"] {
+  flex-shrink: 0;
+  margin-top: 0.15rem;
+  cursor: pointer;
+}
+
+.radioGroup span:first-of-type {
+  font-weight: 500;
+  color: #333;
+}
+
+.description {
+  display: block;
+  font-size: 0.85rem;
+  color: #999;
+  font-weight: normal;
+}
+
+.infoGroup {
+  background: white;
+  padding: 1rem;
+  border-radius: 4px;
+  border: 1px solid #e0e0e0;
+}
+
+.infoPair {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.infoPair:last-child {
+  border-bottom: none;
+}
+
+.label {
+  font-weight: 600;
+  color: #555;
+  min-width: 120px;
+}
+
+.value {
+  color: #333;
+  text-align: right;
+  flex: 1;
+}
+
+.actions {
+  display: flex;
+  gap: 1rem;
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid #e0e0e0;
+}
+
+.saveButton,
+.cancelButton {
+  padding: 0.75rem 1.5rem;
+  border: none;
+  border-radius: 4px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.saveButton {
+  background: #4a90e2;
+  color: white;
+  flex: 1;
+  max-width: 200px;
+}
+
+.saveButton:hover:not(:disabled) {
+  background: #357abd;
+  box-shadow: 0 2px 8px rgba(74, 144, 226, 0.3);
+}
+
+.saveButton:disabled {
+  background: #ccc;
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.cancelButton {
+  background: white;
+  color: #666;
+  border: 1px solid #ddd;
+}
+
+.cancelButton:hover:not(:disabled) {
+  background: #f5f5f5;
+  border-color: #bbb;
+}
+
+.cancelButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.error {
+  background: #fee;
+  border: 1px solid #fcc;
+  color: #c33;
+  padding: 1rem;
+  border-radius: 4px;
+  margin-bottom: 1.5rem;
+  font-size: 0.95rem;
+}
+
+.success {
+  background: #efe;
+  border: 1px solid #cfc;
+  color: #3a3;
+  padding: 1rem;
+  border-radius: 4px;
+  margin-bottom: 1.5rem;
+  font-size: 0.95rem;
+}
+
+/* Modal */
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modalContent {
+  background: white;
+  padding: 2rem;
+  border-radius: 8px;
+  max-width: 400px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+}
+
+.modalContent h4 {
+  margin-bottom: 1rem;
+  color: #333;
+}
+
+.modalContent p {
+  margin-bottom: 1.5rem;
+  color: #666;
+  line-height: 1.5;
+}
+
+.modalActions {
+  display: flex;
+  gap: 1rem;
+}
+
+.confirmButton {
+  flex: 1;
+  padding: 0.75rem 1rem;
+  background: #4a90e2;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.confirmButton:hover {
+  background: #357abd;
+}

--- a/app/UI/src/components/CMS/SiteSettingsPage.jsx
+++ b/app/UI/src/components/CMS/SiteSettingsPage.jsx
@@ -1,0 +1,246 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import api from '../../lib/api';
+import styles from './SiteSettings.module.css';
+
+/**
+ * SiteSettingsPage - Edit site settings (title, tagline, visibility)
+ * Works with PUT /api/sites/{siteId} endpoint (SSG-034)
+ */
+export const SiteSettingsPage = ({ siteId, site = {} }) => {
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState(null);
+  const [success, setSuccess] = useState(false);
+  const [isDirty, setIsDirty] = useState(false);
+
+  const [formData, setFormData] = useState({
+    title: site.title || '',
+    tagline: site.tagline || '',
+    visibility: site.visibility || 'private'
+  });
+
+  const [showVisibilityConfirm, setShowVisibilityConfirm] = useState(false);
+  const [pendingVisibility, setPendingVisibility] = useState(null);
+
+  useEffect(() => {
+    setFormData({
+      title: site.title || '',
+      tagline: site.tagline || '',
+      visibility: site.visibility || 'private'
+    });
+  }, [site]);
+
+  const handleInputChange = (e) => {
+    const { name, value } = e.target;
+    setFormData(prev => ({ ...prev, [name]: value }));
+    setIsDirty(true);
+    setError(null);
+    setSuccess(false);
+  };
+
+  const handleVisibilityChange = (newVisibility) => {
+    if (newVisibility !== formData.visibility) {
+      setPendingVisibility(newVisibility);
+      setShowVisibilityConfirm(true);
+    }
+  };
+
+  const confirmVisibilityChange = () => {
+    setFormData(prev => ({ ...prev, visibility: pendingVisibility }));
+    setShowVisibilityConfirm(false);
+    setPendingVisibility(null);
+    setIsDirty(true);
+  };
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    setError(null);
+    setSuccess(false);
+
+    try {
+      const response = await api.put(`/api/sites/${siteId}`, {
+        title: formData.title,
+        tagline: formData.tagline,
+        visibility: formData.visibility
+      });
+
+      if (response.status === 200) {
+        setSuccess(true);
+        setIsDirty(false);
+        setTimeout(() => setSuccess(false), 3000);
+      }
+    } catch (err) {
+      setError(err.response?.data?.detail || 'Failed to save settings');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleCancel = () => {
+    setFormData({
+      title: site.title || '',
+      tagline: site.tagline || '',
+      visibility: site.visibility || 'private'
+    });
+    setIsDirty(false);
+    setError(null);
+    setSuccess(false);
+  };
+
+  return (
+    <div className={styles.settingsPage}>
+      <h2>Site Settings</h2>
+
+      {error && <div className={styles.error}>{error}</div>}
+      {success && <div className={styles.success}>Settings saved successfully</div>}
+
+      {/* Basic Info Section */}
+      <section className={styles.section}>
+        <h3>Basic Information</h3>
+        <div className={styles.formGroup}>
+          <label htmlFor="title">Site Title</label>
+          <input
+            id="title"
+            name="title"
+            type="text"
+            value={formData.title}
+            onChange={handleInputChange}
+            placeholder="My Blog"
+            maxLength={100}
+          />
+          <p className={styles.hint}>The name of your website</p>
+        </div>
+
+        <div className={styles.formGroup}>
+          <label htmlFor="tagline">Tagline</label>
+          <input
+            id="tagline"
+            name="tagline"
+            type="text"
+            value={formData.tagline}
+            onChange={handleInputChange}
+            placeholder="My thoughts and ideas"
+            maxLength={200}
+          />
+          <p className={styles.hint}>A brief description of your site</p>
+        </div>
+
+        {site.slug && (
+          <div className={styles.formGroup}>
+            <label>Site URL</label>
+            <div className={styles.readOnly}>
+              <code>https://{site.slug}.nbhd.city</code>
+            </div>
+            <p className={styles.hint}>Your unique site address (cannot be changed)</p>
+          </div>
+        )}
+      </section>
+
+      {/* Visibility Section */}
+      <section className={styles.section}>
+        <h3>Visibility & Access</h3>
+        <div className={styles.formGroup}>
+          <fieldset>
+            <legend>Who can see your site?</legend>
+            <div className={styles.radioGroup}>
+              <label>
+                <input
+                  type="radio"
+                  value="public"
+                  checked={formData.visibility === 'public'}
+                  onChange={() => handleVisibilityChange('public')}
+                />
+                <span>Public</span>
+                <span className={styles.description}>Everyone can view your site</span>
+              </label>
+              <label>
+                <input
+                  type="radio"
+                  value="private"
+                  checked={formData.visibility === 'private'}
+                  onChange={() => handleVisibilityChange('private')}
+                />
+                <span>Private</span>
+                <span className={styles.description}>Only you can view your site</span>
+              </label>
+            </div>
+          </fieldset>
+        </div>
+      </section>
+
+      {/* Template Info Section */}
+      {site.template && (
+        <section className={styles.section}>
+          <h3>Template Information</h3>
+          <div className={styles.infoGroup}>
+            <div className={styles.infoPair}>
+              <span className={styles.label}>Template:</span>
+              <span className={styles.value}>{site.template}</span>
+            </div>
+            {site.created_at && (
+              <div className={styles.infoPair}>
+                <span className={styles.label}>Created:</span>
+                <span className={styles.value}>
+                  {new Date(site.created_at).toLocaleDateString()}
+                </span>
+              </div>
+            )}
+          </div>
+          <p className={styles.hint}>Template information cannot be changed. Create a new site to use a different template.</p>
+        </section>
+      )}
+
+      {/* Action Buttons */}
+      <div className={styles.actions}>
+        <button
+          className={styles.saveButton}
+          onClick={handleSave}
+          disabled={!isDirty || isSaving}
+        >
+          {isSaving ? 'Saving...' : 'Save Changes'}
+        </button>
+        <button
+          className={styles.cancelButton}
+          onClick={handleCancel}
+          disabled={!isDirty}
+        >
+          Cancel
+        </button>
+      </div>
+
+      {/* Visibility Confirmation Modal */}
+      {showVisibilityConfirm && (
+        <div className={styles.modal}>
+          <div className={styles.modalContent}>
+            <h4>Change Site Visibility?</h4>
+            <p>
+              You're changing your site from {formData.visibility} to {pendingVisibility}. Continue?
+            </p>
+            <div className={styles.modalActions}>
+              <button onClick={confirmVisibilityChange} className={styles.confirmButton}>
+                Yes, Change
+              </button>
+              <button onClick={() => setShowVisibilityConfirm(false)} className={styles.cancelButton}>
+                Keep {formData.visibility}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+SiteSettingsPage.propTypes = {
+  siteId: PropTypes.string.isRequired,
+  site: PropTypes.shape({
+    title: PropTypes.string,
+    tagline: PropTypes.string,
+    visibility: PropTypes.string,
+    template: PropTypes.string,
+    slug: PropTypes.string,
+    created_at: PropTypes.string
+  })
+};
+
+export default SiteSettingsPage;

--- a/app/UI/src/pages/SiteContentManager.jsx
+++ b/app/UI/src/pages/SiteContentManager.jsx
@@ -8,7 +8,7 @@ import ContentBrowser from '../components/CMS/ContentBrowser';
 import EnhancedContentEditor from '../components/CMS/EnhancedContentEditor';
 import PageManager from '../components/CMS/PageManager';
 import MenuManager from '../components/CMS/MenuManager';
-import { SiteSettingsManager } from '../components/CMS/SiteSettingsManager';
+import { SiteSettingsPage } from '../components/CMS/SiteSettingsPage';
 import styles from '../styles/SiteContentManager.module.css';
 
 /**
@@ -212,8 +212,7 @@ export default function SiteContentManager() {
 
           {activeTab === 'settings' && (
             <div className={styles.section}>
-              <h2>Settings</h2>
-              <SiteSettingsManager siteId={siteId} site={site} />
+              <SiteSettingsPage siteId={siteId} site={site} />
             </div>
           )}
         </div>

--- a/app/api/models.py
+++ b/app/api/models.py
@@ -173,6 +173,8 @@ class SiteUpdate(BaseModel):
     """Schema for updating a site."""
 
     title: Optional[str] = None
+    tagline: Optional[str] = None
+    visibility: Optional[str] = None  # "public" or "private"
     config: Optional[Dict] = None
 
     class Config:

--- a/app/api/sites.py
+++ b/app/api/sites.py
@@ -285,6 +285,20 @@ async def update_site(
                 detail="You do not have permission to update this site"
             )
 
+        # Validate title if provided (not empty string)
+        if site_data.title is not None and site_data.title == "":
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Site title cannot be empty"
+            )
+
+        # Validate visibility if provided
+        if site_data.visibility is not None and site_data.visibility not in ["public", "private"]:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Visibility must be 'public' or 'private'"
+            )
+
         # Config validation against schema
         if site_data.config is not None:
             schema = _get_template_schema(site.get("template", ""))
@@ -303,16 +317,26 @@ async def update_site(
         if site_data.title is not None:
             update_expr += ", title = :title"
             expr_values[":title"] = site_data.title
+        if site_data.tagline is not None:
+            update_expr += ", tagline = :tagline"
+            expr_values[":tagline"] = site_data.tagline
+        if site_data.visibility is not None:
+            update_expr += ", visibility = :visibility"
+            expr_values[":visibility"] = site_data.visibility
         if site_data.config is not None:
             update_expr += ", #config = :config"
             expr_values[":config"] = site_data.config
 
-        await table.update_item(
-            Key={"PK": f"SITE#{site_id}", "SK": "METADATA"},
-            UpdateExpression=update_expr,
-            ExpressionAttributeValues=expr_values,
-            ExpressionAttributeNames={"#config": "config"}
-        )
+        update_kwargs = {
+            "Key": {"PK": f"SITE#{site_id}", "SK": "METADATA"},
+            "UpdateExpression": update_expr,
+            "ExpressionAttributeValues": expr_values,
+        }
+        # Only add ExpressionAttributeNames if we're updating config (which uses #config)
+        if site_data.config is not None:
+            update_kwargs["ExpressionAttributeNames"] = {"#config": "config"}
+
+        await table.update_item(**update_kwargs)
 
         # Fetch updated site
         updated_site = await get_site_db(table, site_id)

--- a/app/api/tests/integration/test_ssg034_site_settings.py
+++ b/app/api/tests/integration/test_ssg034_site_settings.py
@@ -1,0 +1,264 @@
+"""
+Integration Tests for SSG-034: Site Settings & Configuration
+
+Tests for updating site settings: title, tagline, visibility, and configuration.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+class TestUpdateSiteSettings:
+    """Test updating site settings"""
+
+    def test_update_site_title(self, client, auth_headers):
+        """Update site title and verify it's saved"""
+        # Create a site
+        create_response = client.post(
+            "/api/sites",
+            headers=auth_headers,
+            json={
+                "title": "Original Title",
+                "template": "blog",
+                "config": {
+                    "site_title": "Blog",
+                    "author": "Author"
+                }
+            }
+        )
+        assert create_response.status_code == 201
+        site_id = create_response.json()["data"]["site_id"]
+
+        # Update title
+        update_response = client.put(
+            f"/api/sites/{site_id}",
+            headers=auth_headers,
+            json={"title": "Updated Title"}
+        )
+        assert update_response.status_code == 200
+        updated_site = update_response.json()["data"]
+        assert updated_site["title"] == "Updated Title"
+
+    def test_update_site_tagline(self, client, auth_headers):
+        """Update site tagline and verify it's saved"""
+        # Create a site
+        create_response = client.post(
+            "/api/sites",
+            headers=auth_headers,
+            json={
+                "title": "My Site",
+                "template": "blog",
+                "config": {
+                    "site_title": "Blog",
+                    "author": "Author"
+                }
+            }
+        )
+        assert create_response.status_code == 201
+        site_id = create_response.json()["data"]["site_id"]
+
+        # Update tagline
+        update_response = client.put(
+            f"/api/sites/{site_id}",
+            headers=auth_headers,
+            json={"tagline": "My awesome blog"}
+        )
+        assert update_response.status_code == 200
+        updated_site = update_response.json()["data"]
+        assert updated_site.get("tagline") == "My awesome blog"
+
+    def test_update_site_visibility_public(self, client, auth_headers):
+        """Set site visibility to public"""
+        # Create a site
+        create_response = client.post(
+            "/api/sites",
+            headers=auth_headers,
+            json={
+                "title": "My Site",
+                "template": "blog",
+                "config": {
+                    "site_title": "Blog",
+                    "author": "Author"
+                }
+            }
+        )
+        assert create_response.status_code == 201
+        site_id = create_response.json()["data"]["site_id"]
+
+        # Set visibility to public
+        update_response = client.put(
+            f"/api/sites/{site_id}",
+            headers=auth_headers,
+            json={"visibility": "public"}
+        )
+        assert update_response.status_code == 200
+        updated_site = update_response.json()["data"]
+        assert updated_site.get("visibility") == "public"
+
+    def test_update_site_visibility_private(self, client, auth_headers):
+        """Set site visibility to private"""
+        # Create a site
+        create_response = client.post(
+            "/api/sites",
+            headers=auth_headers,
+            json={
+                "title": "My Site",
+                "template": "blog",
+                "config": {
+                    "site_title": "Blog",
+                    "author": "Author"
+                }
+            }
+        )
+        assert create_response.status_code == 201
+        site_id = create_response.json()["data"]["site_id"]
+
+        # Set visibility to private
+        update_response = client.put(
+            f"/api/sites/{site_id}",
+            headers=auth_headers,
+            json={"visibility": "private"}
+        )
+        assert update_response.status_code == 200
+        updated_site = update_response.json()["data"]
+        assert updated_site.get("visibility") == "private"
+
+    def test_update_site_multiple_fields(self, client, auth_headers):
+        """Update multiple fields at once"""
+        # Create a site
+        create_response = client.post(
+            "/api/sites",
+            headers=auth_headers,
+            json={
+                "title": "Original",
+                "template": "blog",
+                "config": {
+                    "site_title": "Blog",
+                    "author": "Author"
+                }
+            }
+        )
+        assert create_response.status_code == 201
+        site_id = create_response.json()["data"]["site_id"]
+
+        # Update multiple fields
+        update_response = client.put(
+            f"/api/sites/{site_id}",
+            headers=auth_headers,
+            json={
+                "title": "New Title",
+                "tagline": "A new tagline",
+                "visibility": "public"
+            }
+        )
+        assert update_response.status_code == 200
+        updated_site = update_response.json()["data"]
+        assert updated_site["title"] == "New Title"
+        assert updated_site.get("tagline") == "A new tagline"
+        assert updated_site.get("visibility") == "public"
+
+
+class TestUpdateSiteSettingsValidation:
+    """Test validation of site settings updates"""
+
+    def test_update_site_empty_title_rejected(self, client, auth_headers):
+        """Empty title string is rejected"""
+        # Create a site
+        create_response = client.post(
+            "/api/sites",
+            headers=auth_headers,
+            json={
+                "title": "My Site",
+                "template": "blog",
+                "config": {
+                    "site_title": "Blog",
+                    "author": "Author"
+                }
+            }
+        )
+        assert create_response.status_code == 201
+        site_id = create_response.json()["data"]["site_id"]
+
+        # Try to update with empty title
+        update_response = client.put(
+            f"/api/sites/{site_id}",
+            headers=auth_headers,
+            json={"title": ""}
+        )
+        assert update_response.status_code == 400
+        assert "empty" in update_response.json()["detail"].lower()
+
+    def test_update_site_invalid_visibility(self, client, auth_headers):
+        """Invalid visibility value is rejected"""
+        # Create a site
+        create_response = client.post(
+            "/api/sites",
+            headers=auth_headers,
+            json={
+                "title": "My Site",
+                "template": "blog",
+                "config": {
+                    "site_title": "Blog",
+                    "author": "Author"
+                }
+            }
+        )
+        assert create_response.status_code == 201
+        site_id = create_response.json()["data"]["site_id"]
+
+        # Try to update with invalid visibility
+        update_response = client.put(
+            f"/api/sites/{site_id}",
+            headers=auth_headers,
+            json={"visibility": "hidden"}
+        )
+        assert update_response.status_code == 400
+        assert "public" in update_response.json()["detail"].lower() or "private" in update_response.json()["detail"].lower()
+
+    def test_update_site_requires_auth(self, client):
+        """Update endpoint requires authentication"""
+        response = client.put(
+            "/api/sites/test-site-id",
+            json={"title": "New Title"}
+        )
+        assert response.status_code == 401
+
+    def test_update_nonexistent_site(self, client, auth_headers):
+        """Updating nonexistent site returns 404"""
+        response = client.put(
+            "/api/sites/nonexistent-site-id",
+            headers=auth_headers,
+            json={"title": "New Title"}
+        )
+        assert response.status_code == 404
+
+    def test_update_site_wrong_owner(self, client, auth_headers):
+        """Only site owner can update"""
+        from auth import create_access_token
+
+        # Create a site
+        create_response = client.post(
+            "/api/sites",
+            headers=auth_headers,
+            json={
+                "title": "My Site",
+                "template": "blog",
+                "config": {
+                    "site_title": "Blog",
+                    "author": "Author"
+                }
+            }
+        )
+        assert create_response.status_code == 201
+        site_id = create_response.json()["data"]["site_id"]
+
+        # Try to update with different user
+        other_token = create_access_token(user_id="did:plc:other")
+        other_headers = {"Authorization": f"Bearer {other_token}"}
+
+        update_response = client.put(
+            f"/api/sites/{site_id}",
+            headers=other_headers,
+            json={"title": "Hacked Title"}
+        )
+        assert update_response.status_code == 403


### PR DESCRIPTION
## Summary
Implements SSG-034: Site Settings & Configuration. Users can now modify site settings (title, tagline, visibility) after site creation. Includes validation, confirmation dialogs for visibility changes, and comprehensive test coverage.

## Changes

**Backend:**
- Add `tagline` and `visibility` fields to SiteUpdate model in models.py
- Update PUT /api/sites/{site_id} endpoint to handle new fields with validation
- Validate empty titles and invalid visibility values
- Fix DynamoDB expression attribute names handling

**Frontend:**
- Create new SiteSettingsPage component with form for updating site settings
- Visibility toggle with confirmation dialog
- Read-only display of immutable fields (slug, template)
- Success/error notifications

**Tests:**
- 10 integration tests covering all update scenarios
- Tests for validation (empty title, invalid visibility)
- Tests for auth and ownership checks

## Testing
✅ All 10 integration tests passing:
- test_update_site_title
- test_update_site_tagline
- test_update_site_visibility_public
- test_update_site_visibility_private
- test_update_site_multiple_fields
- test_update_site_empty_title_rejected
- test_update_site_invalid_visibility
- test_update_site_requires_auth
- test_update_nonexistent_site
- test_update_site_wrong_owner

## Related Ticket
- SSG-034: Site Settings & Configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)